### PR TITLE
[Fix] guard legacyFilesToAppend

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ EmberApp.prototype.javascript = function() {
   let deprecate = this.project.ui.writeDeprecateLine.bind(this.project.ui);
   let applicationJs = this.appAndDependencies();
 
-  if (this.legacyFilesToAppend.length > 0) {
+  if (this.legacyFilesToAppend && this.legacyFilesToAppend.length > 0) {
     deprecate(`Usage of EmberApp.legacyFilesToAppend is deprecated. ` +
       `Please use EmberApp.import instead for the following files: '${this.legacyFilesToAppend.join('\', \'')}'`);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-tree-shaker",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Experiment with tree-shaking in Ember CLI",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Using ember-cli: 3.0.1
It appears `legacyFileToAppend` has been deprecated in version 3.  
https://github.com/ember-cli/ember-cli/pull/7523/files